### PR TITLE
3 peticiones del cliente corregidas

### DIFF
--- a/src/app/components/boat-section/boat-create-update-modal/boat-create-update-modal.component.html
+++ b/src/app/components/boat-section/boat-create-update-modal/boat-create-update-modal.component.html
@@ -1,4 +1,4 @@
-<div (click)="closeModal()" class="modal-overlay">
+<div class="modal-overlay">
   <div (click)="clickModal = true" class="modal-container">
     <div class="modal__close">
       <svg (click)="closeModal()" xmlns="http//www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 96 96">

--- a/src/app/components/boat-section/boat-create-update-modal/boat-create-update-modal.component.ts
+++ b/src/app/components/boat-section/boat-create-update-modal/boat-create-update-modal.component.ts
@@ -83,13 +83,13 @@ export class BoatCreateUpdateModalComponent implements OnInit, OnDestroy {
   }
 
   public closeModal(isSendRequest: boolean = false): void {
-
+    this.clickModal = false;
     if (this.clickModal == false && !this.isLoading) {
 
       this.boatForm.reset();
       this.closeModalEvent.emit(isSendRequest);
     }
-    this.clickModal = false;
+    
   }
 
   public onSubmit(): void {

--- a/src/app/components/boat-section/boat-view-modal/boat-view-modal.component.html
+++ b/src/app/components/boat-section/boat-view-modal/boat-view-modal.component.html
@@ -1,4 +1,4 @@
-<div (click)="closeModal()" class="modal-overlay">
+<div class="modal-overlay">
     <div (click)="clickModal = true" class="modal-container">
         <div class="modal__close">
             <svg (click)="closeModal()" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 96 96">

--- a/src/app/components/boat-section/boat-view-modal/boat-view-modal.component.ts
+++ b/src/app/components/boat-section/boat-view-modal/boat-view-modal.component.ts
@@ -66,11 +66,11 @@ export class BoatViewModalComponent implements OnInit, OnDestroy {
   }
 
   public closeModal(): void {
-
+    this.clickModal = false;
     if (this.clickModal == false) {
       this.closeModalEvent.emit();
     }
-    this.clickModal = false;
+    
   }
 
   private getBoatById(idBoat:string):Subscription{

--- a/src/app/components/company-section/company-create-update-modal/company-create-update-modal.component.html
+++ b/src/app/components/company-section/company-create-update-modal/company-create-update-modal.component.html
@@ -1,4 +1,4 @@
-<div (click)="closeModal()" class="modal-overlay">
+<div class="modal-overlay">
   <div (click)="clickModal = true" class="modal-container">
     <div class="modal__close">
       <svg (click)="closeModal()" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 96 96">

--- a/src/app/components/company-section/company-create-update-modal/company-create-update-modal.component.ts
+++ b/src/app/components/company-section/company-create-update-modal/company-create-update-modal.component.ts
@@ -76,14 +76,14 @@ export class CompanyCreateUpdateModalComponent implements OnInit, OnDestroy {
   }
 
   public closeModal(isSendRequest: boolean = false): void {
-
+    this.clickModal = false;
     if (this.clickModal == false && !this.isLoading) {
 
       this.companyForm.reset();
       this.closeModalEvent.emit(isSendRequest);
     }
 
-    this.clickModal = false;
+    
   }
 
   public onSubmit(): void {

--- a/src/app/components/company-section/company-view-modal/company-view-modal.component.html
+++ b/src/app/components/company-section/company-view-modal/company-view-modal.component.html
@@ -1,4 +1,4 @@
-<div (click)="closeModal()" class="modal-overlay">
+<div class="modal-overlay">
   <div (click)="clickModal = true" class="modal-container">
     <div class="modal__close">
       <svg (click)="closeModal()" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 96 96">

--- a/src/app/components/company-section/company-view-modal/company-view-modal.component.ts
+++ b/src/app/components/company-section/company-view-modal/company-view-modal.component.ts
@@ -47,11 +47,11 @@ export class CompanyViewModalComponent implements OnInit, OnDestroy {
   }
 
   public closeModal() {
-
+    this.clickModal = false;
     if (this.clickModal == false && !this.isLoading) {
       this.closeModalEvent.emit();
     }
-    this.clickModal = false;
+    
   }
 
   private getCompanyById(idCompany: string): Subscription {

--- a/src/app/components/confirm-delete-modal/confirm-delete-modal.component.html
+++ b/src/app/components/confirm-delete-modal/confirm-delete-modal.component.html
@@ -1,4 +1,4 @@
-<div class="modal-overlay" (click)="closeModal()">
+<div class="modal-overlay" >
   <div (click)="clickModal = true" class="modal-container">
 
     <h2 class="modal__title">¿DESEAS ELIMINAR EL REGISTRO?</h2>

--- a/src/app/components/confirm-delete-modal/confirm-delete-modal.component.ts
+++ b/src/app/components/confirm-delete-modal/confirm-delete-modal.component.ts
@@ -62,11 +62,11 @@ export class ConfirmDeleteModalComponent implements OnDestroy {
   }
 
   public closeModal(isSendRequest:boolean = false) {
-
+    this.clickModal = false;
     if (this.clickModal == false && !this.isLoading) {
       this.closeModalEvent.emit(isSendRequest);
     }
-    this.clickModal = false;
+    
   }
 
   public delete(): void {

--- a/src/app/components/expiration-section/expiration-create-update-modal/expiration-create-update-modal.component.html
+++ b/src/app/components/expiration-section/expiration-create-update-modal/expiration-create-update-modal.component.html
@@ -1,4 +1,4 @@
-<div (click)="closeModal()" class="modal-overlay">
+<div class="modal-overlay">
     <div (click)="clickModal = true" class="modal-container">
         <div class="modal__close">
             <svg (click)="closeModal()" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 96 96">

--- a/src/app/components/expiration-section/expiration-create-update-modal/expiration-create-update-modal.component.ts
+++ b/src/app/components/expiration-section/expiration-create-update-modal/expiration-create-update-modal.component.ts
@@ -71,13 +71,12 @@ export class ExpirationCreateUpdateModalComponent implements OnInit, OnDestroy {
   }
 
   public closeModal(isSendRequest: boolean = false): void {
+    this.clickModal = false;
     if (this.clickModal == false && !this.isLoading) {
 
       this.expirationForm.reset();
       this.closeModalEvent.emit(isSendRequest);
     }
-
-    this.clickModal = false;
   }
 
   public onSubmit(): void {

--- a/src/app/components/expiration-section/expiration-section.component.html
+++ b/src/app/components/expiration-section/expiration-section.component.html
@@ -111,7 +111,7 @@
             class="table__row-body"
             *ngFor="
               let expiration of expirationList
-                | paginate : { itemsPerPage: 7, currentPage: currentPage }
+                | paginate : { itemsPerPage: 15, currentPage: currentPage }
             "
           >
             <td style="display: none">{{ expiration.IdExpiration }}</td>

--- a/src/app/components/expiration-section/expiration-section.component.scss
+++ b/src/app/components/expiration-section/expiration-section.component.scss
@@ -166,7 +166,7 @@
           border-bottom: 5px solid white;
 
           th {
-            width: 210px;
+            width: 16.666%;
             padding: 20px;
             color: white;
           }
@@ -197,7 +197,7 @@
           }
 
           td {
-            width: 210px;
+            width: 16.666%;
             padding: 20px;
           }
 

--- a/src/app/components/expiration-section/expiration-view-modal/expiration-view-modal.component.html
+++ b/src/app/components/expiration-section/expiration-view-modal/expiration-view-modal.component.html
@@ -1,4 +1,4 @@
-<div (click)="closeModal()" class="modal-overlay">
+<div class="modal-overlay">
   <div (click)="clickModal = true" class="modal-container">
     <div class="modal__close">
       <svg

--- a/src/app/components/expiration-section/expiration-view-modal/expiration-view-modal.component.ts
+++ b/src/app/components/expiration-section/expiration-view-modal/expiration-view-modal.component.ts
@@ -54,11 +54,11 @@ export class ExpirationViewModalComponent implements OnInit, OnDestroy {
   }
 
   public closeModal(): void {
-
+    this.clickModal = false;
     if (this.clickModal == false) {
       this.closeModalEvent.emit();
     }
-    this.clickModal = false;
+    
   }
 
   private getExpirationById(idExpiration: string): Subscription {

--- a/src/app/components/generator-section/generator-create-update-modal/generator-create-update-modal.component.html
+++ b/src/app/components/generator-section/generator-create-update-modal/generator-create-update-modal.component.html
@@ -1,4 +1,4 @@
-<div (click)="closeModal()" class="modal-overlay">
+<div class="modal-overlay">
     <div (click)="clickModal = true" class="modal-container">
         <div class="modal__close">
             <svg (click)="closeModal()" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 96 96">

--- a/src/app/components/generator-section/generator-create-update-modal/generator-create-update-modal.component.ts
+++ b/src/app/components/generator-section/generator-create-update-modal/generator-create-update-modal.component.ts
@@ -70,13 +70,14 @@ export class GeneratorCreateUpdateModalComponent implements OnInit, OnDestroy {
   }
 
   public closeModal(isSendRequest: boolean = false): void {
+    this.clickModal = false;
     if (this.clickModal == false && !this.isLoading) {
 
       this.generatorForm.reset();
       this.closeModalEvent.emit(isSendRequest);
     }
 
-    this.clickModal = false;
+    
   }
 
   public onSubmit(): void {

--- a/src/app/components/generator-section/generator-view-modal/generator-view-modal.component.html
+++ b/src/app/components/generator-section/generator-view-modal/generator-view-modal.component.html
@@ -1,4 +1,4 @@
-<div (click)="closeModal()" class="modal-overlay">
+<div class="modal-overlay">
     <div (click)="clickModal = true" class="modal-container">
         <div class="modal__close">
             <svg (click)="closeModal()" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 96 96">

--- a/src/app/components/generator-section/generator-view-modal/generator-view-modal.component.ts
+++ b/src/app/components/generator-section/generator-view-modal/generator-view-modal.component.ts
@@ -52,11 +52,11 @@ export class GeneratorViewModalComponent implements OnInit, OnDestroy {
   }
 
   public closeModal(): void {
-
+    this.clickModal = false;
     if (this.clickModal == false) {
       this.closeModalEvent.emit();
     }
-    this.clickModal = false;
+    
   }
 
   private getGeneratorById(idGenerator:string):Subscription{

--- a/src/app/components/motor-section/motor-create-update-modal/motor-create-update-modal.component.html
+++ b/src/app/components/motor-section/motor-create-update-modal/motor-create-update-modal.component.html
@@ -1,4 +1,4 @@
-<div (click)="closeModal()" class="modal-overlay">
+<div class="modal-overlay">
     <div (click)="clickModal = true" class="modal-container">
         <div class="modal__close">
             <svg (click)="closeModal()" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 96 96">

--- a/src/app/components/motor-section/motor-create-update-modal/motor-create-update-modal.component.ts
+++ b/src/app/components/motor-section/motor-create-update-modal/motor-create-update-modal.component.ts
@@ -71,13 +71,14 @@ export class MotorCreateUpdateModalComponent implements OnInit, OnDestroy {
   }
 
   public closeModal(isSendRequest: boolean = false): void {
+    this.clickModal = false;
     if (this.clickModal == false && !this.isLoading) {
 
       this.motorForm.reset();
       this.closeModalEvent.emit(isSendRequest);
     }
 
-    this.clickModal = false;
+    
   }
 
   public onSubmit(): void {

--- a/src/app/components/motor-section/motor-view-modal/motor-view-modal.component.html
+++ b/src/app/components/motor-section/motor-view-modal/motor-view-modal.component.html
@@ -1,4 +1,4 @@
-<div (click)="closeModal()" class="modal-overlay">
+<div class="modal-overlay">
     <div (click)="clickModal = true" class="modal-container">
         <div class="modal__close">
             <svg (click)="closeModal()" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 96 96">

--- a/src/app/components/motor-section/motor-view-modal/motor-view-modal.component.ts
+++ b/src/app/components/motor-section/motor-view-modal/motor-view-modal.component.ts
@@ -53,11 +53,11 @@ export class MotorViewModalComponent implements OnInit, OnDestroy {
   }
 
   public closeModal(): void {
-
+    this.clickModal = false;
     if (this.clickModal == false) {
       this.closeModalEvent.emit();
     }
-    this.clickModal = false;
+    
   }
 
   private getMotorById(idMotor:string):Subscription{


### PR DESCRIPTION
- Al abrir un modal, que solo se pueda cerrar haciendo click en la “x”.
- Para desktop, en la tabla de vencimientos deben visualizarse todos los campos sin hacer scroll.
- En la tabla de vencimientos, se debe visualizar 15 registros por cada página.